### PR TITLE
Fix Ember variable being set to undefined by module definition (because ember.js doesn't return a module).

### DIFF
--- a/ehbs.js
+++ b/ehbs.js
@@ -1,4 +1,4 @@
-define(["ember"], function (Ember) {
+define(["ember"], function () {
 
   var options = { data: true, stringParams: true };
   var ignore = [


### PR DESCRIPTION
Latest versions of Ember don't export it as a module, but rather set it as a global variable. Irritating as that is, having the module definition with the argument `Ember` sets `Ember` to `undefined` in the module scope, which gives us errors like

> Uncaught TypeError: Cannot read property 'Handlebars' of undefined 

On **ehbs.js:128**. This fixes it.
